### PR TITLE
improvements

### DIFF
--- a/proxy/src/org/phoenixbioinformatics/api/AbstractApiService.java
+++ b/proxy/src/org/phoenixbioinformatics/api/AbstractApiService.java
@@ -11,8 +11,10 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -34,6 +36,23 @@ public abstract class AbstractApiService {
   /** logger for this class */
   private static final Logger logger =
     LogManager.getLogger(AbstractApiService.class);
+
+  private static final PoolingHttpClientConnectionManager API_CONN_MANAGER =
+    new PoolingHttpClientConnectionManager();
+  static {
+    API_CONN_MANAGER.setMaxTotal(200);
+    API_CONN_MANAGER.setDefaultMaxPerRoute(50);
+    API_CONN_MANAGER.setValidateAfterInactivity(5000);
+  }
+  private static final RequestConfig API_REQUEST_CONFIG = RequestConfig.custom()
+    .setConnectTimeout(10000)
+    .setSocketTimeout(30000)
+    .setConnectionRequestTimeout(5000)
+    .build();
+  private static final CloseableHttpClient API_CLIENT = HttpClientBuilder.create()
+    .setConnectionManager(API_CONN_MANAGER)
+    .setDefaultRequestConfig(API_REQUEST_CONFIG)
+    .build();
 
   /**
    * This method handles the call to API service without using cookie and a form
@@ -81,19 +100,22 @@ public abstract class AbstractApiService {
     }
 
     request.addHeader("Cookie", "apiKey=" + API_KEY + ";" + cookieString);
-    CloseableHttpClient client = HttpClientBuilder.create().build();
-    // debug statement. TODO: remove in final produce to reduce spam
-    // logger.debug("Making " + methodString + " request: " + API_URL + urn);
-    response = client.execute(request);
 
-    int status = response.getStatusLine().getStatusCode();
-    if (status != HttpStatus.SC_OK && status != HttpStatus.SC_CREATED) {
-      logger.debug("Status code is not OK: " + status);
-      logger.debug("API Url: " + API_URL);
-      throw new IOException("Bad status code: " + String.valueOf(status));
+    try {
+      response = API_CLIENT.execute(request);
+      int status = response.getStatusLine().getStatusCode();
+      if (status != HttpStatus.SC_OK && status != HttpStatus.SC_CREATED) {
+        logger.debug("Status code is not OK: " + status);
+        logger.debug("API Url: " + API_URL);
+        EntityUtils.consumeQuietly(response.getEntity());
+        throw new IOException("Bad status code: " + String.valueOf(status));
+      }
+      String content = EntityUtils.toString(response.getEntity());
+      return content;
+    } finally {
+      if (response != null) {
+        response.close();
+      }
     }
-    String content = EntityUtils.toString(response.getEntity());
-
-    return content;
   }
 }

--- a/proxy/src/org/phoenixbioinformatics/proxy/Proxy.java
+++ b/proxy/src/org/phoenixbioinformatics/proxy/Proxy.java
@@ -23,6 +23,9 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 
 import javax.servlet.ServletException;
@@ -41,6 +44,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -51,6 +55,7 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.util.EntityUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
@@ -204,6 +209,46 @@ public class Proxy extends HttpServlet {
   //sqs api url
   private static final String API_GATEWAY_SQS_LOGGING_URL =
     ProxyProperties.getProperty("sqs.uri");
+
+  // Shared connection-pooled HttpClient for proxying to backend servers
+  private static final PoolingHttpClientConnectionManager PROXY_CONN_MANAGER =
+    new PoolingHttpClientConnectionManager();
+  static {
+    PROXY_CONN_MANAGER.setMaxTotal(200);
+    PROXY_CONN_MANAGER.setDefaultMaxPerRoute(50);
+    PROXY_CONN_MANAGER.setValidateAfterInactivity(5000);
+  }
+  private static final RequestConfig PROXY_REQUEST_CONFIG = RequestConfig.custom()
+    .setConnectTimeout(10000)
+    .setSocketTimeout(60000)
+    .setConnectionRequestTimeout(5000)
+    .build();
+  private static final CloseableHttpClient PROXY_CLIENT = HttpClientBuilder.create()
+    .setConnectionManager(PROXY_CONN_MANAGER)
+    .setDefaultRequestConfig(PROXY_REQUEST_CONFIG)
+    .disableContentCompression()
+    .disableRedirectHandling()
+    .build();
+
+  // Shared connection-pooled HttpClient for SQS logging
+  private static final PoolingHttpClientConnectionManager SQS_CONN_MANAGER =
+    new PoolingHttpClientConnectionManager();
+  static {
+    SQS_CONN_MANAGER.setMaxTotal(20);
+    SQS_CONN_MANAGER.setDefaultMaxPerRoute(10);
+    SQS_CONN_MANAGER.setValidateAfterInactivity(5000);
+  }
+  private static final RequestConfig SQS_REQUEST_CONFIG = RequestConfig.custom()
+    .setConnectTimeout(5000)
+    .setSocketTimeout(10000)
+    .setConnectionRequestTimeout(3000)
+    .build();
+  private static final CloseableHttpClient SQS_CLIENT = HttpClientBuilder.create()
+    .setConnectionManager(SQS_CONN_MANAGER)
+    .setDefaultRequestConfig(SQS_REQUEST_CONFIG)
+    .build();
+
+  private static final ExecutorService SQS_EXECUTOR = Executors.newFixedThreadPool(4);
 
   @Override
   protected void service(HttpServletRequest servletRequest,
@@ -516,15 +561,19 @@ public class Proxy extends HttpServlet {
               ContentType.APPLICATION_JSON);
       request.setEntity(requestEntity);
 
-      CloseableHttpClient client = HttpClientBuilder.create().build();
-      response = client.execute(request);
-
-      int status = response.getStatusLine().getStatusCode();
-      if (status != HttpStatus.SC_OK && status != HttpStatus.SC_CREATED) {
-        logger.debug("Status creating sqs page view is not OK: " + status);
-        throw new IOException("Bad status code: " + String.valueOf(status));
-      } else {
-        // logger.debug("Status creating sqs page view is OK: " + status);
+      try {
+        response = SQS_CLIENT.execute(request);
+        int status = response.getStatusLine().getStatusCode();
+        if (status != HttpStatus.SC_OK && status != HttpStatus.SC_CREATED) {
+          logger.debug("Status creating sqs page view is not OK: " + status);
+          EntityUtils.consumeQuietly(response.getEntity());
+          throw new IOException("Bad status code: " + String.valueOf(status));
+        }
+        EntityUtils.consumeQuietly(response.getEntity());
+      } finally {
+        if (response != null) {
+          response.close();
+        }
       }
     }
   }
@@ -607,13 +656,16 @@ public class Proxy extends HttpServlet {
             sourceHost,
             partnerId,
             userIdentifier.toString());
-      try {
-        sqsLogRequest(fullRequestUri, remoteIp, orgId, ipListString, credentialId, sessionId, partnerId, isPaidContent, METER_NOT_METERED_STATUS_CODE, String.valueOf(servletResponse.getStatus()), getAllServletResponseHeaders(servletResponse), servletResponse.getContentType());
-      }catch(Exception e){
-        logger.debug("sqs logging error");
-      }
-      //logRequest(fullRequestUri, remoteIp, ipListString, credentialId, sessionId, partnerId, isPaidContent, "N");
-      // logger.debug("userIdentifier after proxy(): " + userIdentifier.toString());
+      final String sqsStatusCode = String.valueOf(servletResponse.getStatus());
+      final String sqsResponseHeaders = getAllServletResponseHeaders(servletResponse);
+      final String sqsContentType = servletResponse.getContentType();
+      SQS_EXECUTOR.submit(() -> {
+        try {
+          sqsLogRequest(fullRequestUri, remoteIp, orgId, ipListString, credentialId, sessionId, partnerId, isPaidContent, METER_NOT_METERED_STATUS_CODE, sqsStatusCode, sqsResponseHeaders, sqsContentType);
+        } catch (Exception e) {
+          logger.warn("sqs logging error for URI: " + fullRequestUri, e);
+        }
+      });
     }
   }
 
@@ -902,12 +954,17 @@ public class Proxy extends HttpServlet {
             "\nParty: " + credentialId  + ", Action: Not authorized, Partner: " + partnerId +
             "\nRedirecting to: " + redirectUri);
 
-      try {
-        sqsLogRequest(fullUri, remoteIp, orgId, ipListString, credentialId, sessionId, partnerId, isPaidContent, meterStatus, String.valueOf(servletResponse.getStatus()),getAllServletResponseHeaders(servletResponse), servletResponse.getContentType());
-      }catch(Exception e){
-        logger.debug("sqs logging error");
-      }
-      //logRequest(fullUri, remoteIp, ipListString, credentialId, sessionId, partnerId, isPaidContent, meterStatus);
+      final String sqsMeterStatus = meterStatus;
+      final String sqsStatusCode2 = String.valueOf(servletResponse.getStatus());
+      final String sqsResponseHeaders2 = getAllServletResponseHeaders(servletResponse);
+      final String sqsContentType2 = servletResponse.getContentType();
+      SQS_EXECUTOR.submit(() -> {
+        try {
+          sqsLogRequest(fullUri, remoteIp, orgId, ipListString, credentialId, sessionId, partnerId, isPaidContent, sqsMeterStatus, sqsStatusCode2, sqsResponseHeaders2, sqsContentType2);
+        } catch (Exception e) {
+          logger.warn("sqs logging error for URI: " + fullUri, e);
+        }
+      });
       if (allowRedirect) {
         servletResponse.sendRedirect(redirectUri + "&remoteIp=" +remoteIp);
       } else {
@@ -1019,7 +1076,6 @@ public class Proxy extends HttpServlet {
                                    ResponseHandler<String> responseHandler,
                                    String userIdentifier)
       throws ClientProtocolException, IOException {
-    CloseableHttpClient client = null;
     // Get cookie store from session if it's there. This gets stored in the
     // proxy server session to maintain the session from the back-end server.
     CookieStore cookieStore =
@@ -1028,15 +1084,10 @@ public class Proxy extends HttpServlet {
       createLocalContextWithCookiesAndTarget(host,
                                              cookieStore,
                                              request.getURI().getHost());
-    client = HttpClientBuilder.create().disableContentCompression().disableRedirectHandling().build();
-    // Execute the request on the proxied server. Ignore returned string.
-    // TODO: try adding host as first param, see if it does the right thing.
-    // client.execute(host, request, responseHandler, localContext);
-    // logAllUriRequestHeaders(request);
 
     // PWL-625: Add measure to method duration
     long startTime = System.currentTimeMillis();
-    client.execute(request, responseHandler, localContext);
+    PROXY_CLIENT.execute(request, responseHandler, localContext);
     long stopTime = System.currentTimeMillis();
     long elapsedTime = stopTime - startTime;
     if (elapsedTime >= CONTENT_REQUEST_THRESHOLD * 1000) {
@@ -1822,5 +1873,21 @@ public class Proxy extends HttpServlet {
       }
       response.addCookie(cookie);
     }
+  }
+
+  @Override
+  public void destroy() {
+    SQS_EXECUTOR.shutdown();
+    try {
+      if (!SQS_EXECUTOR.awaitTermination(5, TimeUnit.SECONDS)) {
+        SQS_EXECUTOR.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      SQS_EXECUTOR.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+    try { PROXY_CLIENT.close(); } catch (IOException e) { logger.warn("Error closing PROXY_CLIENT", e); }
+    try { SQS_CLIENT.close(); } catch (IOException e) { logger.warn("Error closing SQS_CLIENT", e); }
+    super.destroy();
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core request proxying and logging paths by introducing shared pooled HTTP clients and asynchronous logging, which could affect throughput or behavior under load if pooling/threading is misconfigured.
> 
> **Overview**
> Improves proxy/API HTTP call performance and stability by switching from per-request `HttpClient` construction to shared, connection-pooled clients with explicit timeouts.
> 
> `AbstractApiService` and `Proxy` now reuse pooled `CloseableHttpClient` instances, ensure response entities are consumed on error paths, and always close `CloseableHttpResponse` objects.
> 
> SQS page-view logging is moved off the request thread via a small `ExecutorService`, with better warning logs on failures and explicit shutdown/cleanup in `Proxy.destroy()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4b12ad26c2d2d5aca46f4a37f1a94c3c16c7ec7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->